### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -71,12 +71,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "5d6430816fd4afb6b87251b06e7eabcefba47610"
+                "reference": "d7323652d345582c97c7ca2e23f70984b76e8e3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/5d6430816fd4afb6b87251b06e7eabcefba47610",
-                "reference": "5d6430816fd4afb6b87251b06e7eabcefba47610",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/d7323652d345582c97c7ca2e23f70984b76e8e3a",
+                "reference": "d7323652d345582c97c7ca2e23f70984b76e8e3a",
                 "shasum": ""
             },
             "require": {
@@ -111,7 +111,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable32"
             },
-            "time": "2026-03-21T01:05:00+00:00"
+            "time": "2026-04-09T01:10:47+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency